### PR TITLE
Expose Router.Actions to allow annotating main.

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -9,6 +9,7 @@
     "exposed-modules": [
         "Router",
         "Router.Types",
+        "Router.Actions",
         "URL.Segments",
         "URL.Route",
         "URL.Matcher"


### PR DESCRIPTION
Hey, great work you have there! Helped me a lot learning Elm.

When following the README.md, Elm suggests to add a type annotation to my main Program (I always use `--warn`):

```elm
Top-level value `main` does not have a type annotation.

46| main =
    ^^^^
I inferred the type annotation so you can copy it into your code:

main :
    Program 
        Never
        (
        Router.WithRouter
            Route
            { ... }
        )
        (Router.Actions.Msg Route Msg)
```

When I follow that advice, adding the following type annotation:
```elm
main : Program Never State (Router.Actions.Msg Route Msg)
```

... Elm asks to import `Router.Actions`. Despite this file existing and being stored in the right location of your package, this fails:

```elm
I cannot find module 'Router.Actions'.
```

This patch exposes that module so I can make the warnings to go away.

PS: I tried to setup an ellie, but it won't properly save a non-compiling program.